### PR TITLE
optimize the clear head method from SetData to a CS kernel

### DIFF
--- a/Assets/OrderIndependentTransparency/Scripts/OitLinkedList.cs
+++ b/Assets/OrderIndependentTransparency/Scripts/OitLinkedList.cs
@@ -38,16 +38,12 @@ public class OitLinkedList : IOrderIndependentTransparency
         startOffsetBuffer = new GraphicsBuffer(GraphicsBuffer.Target.Raw, bufferSizeHead, bufferStrideHead);
         startOffsetBufferId = Shader.PropertyToID("StartOffsetBuffer");
 
+
         OitComputeUtils = Resources.Load<ComputeShader>("OitComputeUtils");
         clearStartOffsetBufferKernel = OitComputeUtils.FindKernel("ClearStartOffsetBuffer");
         OitComputeUtils.SetBuffer(clearStartOffsetBufferKernel, startOffsetBufferId, startOffsetBuffer);
-        dispatchHeadSize = Mathf.CeilToInt(bufferSizeHead / 64);
-        if (dispatchHeadSize > ushort.MaxValue)
-        {
-            dispatchHeadSize = ushort.MaxValue;
-            Debug.LogError("Too Large Screen Size");
-        }
-
+        OitComputeUtils.SetInt("bufferSizeHead", bufferSizeHead);
+        dispatchHeadSize = Mathf.Min(Mathf.CeilToInt(bufferSizeHead / 64.0f),65535);
     }
 
     public void PreRender()

--- a/Assets/OrderIndependentTransparency/Shaders/LinkedListCreation.cginc
+++ b/Assets/OrderIndependentTransparency/Shaders/LinkedListCreation.cginc
@@ -16,7 +16,7 @@ RWByteAddressBuffer StartOffsetBuffer : register(u2);
 
 void createFragmentEntry(float4 col, float3 pos, uint uCoverage) {
     //Retrieve current Pixel count and increase counter
-    uint uPixelCount = FLBuffer.IncrementCounter();
+    uint uPixelCount = FLBuffer.IncrementCounter()+1;
 
     //calculate bufferAddress
     uint uStartOffsetAddress = 4 * (_ScreenParams.x * (pos.y - 0.5) + (pos.x - 0.5));

--- a/Assets/OrderIndependentTransparency/Shaders/Resources/OitComputeUtils.compute
+++ b/Assets/OrderIndependentTransparency/Shaders/Resources/OitComputeUtils.compute
@@ -1,10 +1,12 @@
 #pragma kernel ClearStartOffsetBuffer
 
 RWStructuredBuffer<uint> StartOffsetBuffer;
-uint IndexOffset = 0;
+uint bufferSizeHead ;
 
 [numthreads(64,1,1)]
 void ClearStartOffsetBuffer (uint3 id : SV_DispatchThreadID)
 {
-    StartOffsetBuffer[id.x+IndexOffset] = 0;
+    for(uint i=0;i<bufferSizeHead;i+=4194240){
+        StartOffsetBuffer[id.x + i] = 0;
+    }
 }

--- a/Assets/OrderIndependentTransparency/Shaders/Resources/OitComputeUtils.compute
+++ b/Assets/OrderIndependentTransparency/Shaders/Resources/OitComputeUtils.compute
@@ -1,12 +1,10 @@
 #pragma kernel ClearStartOffsetBuffer
 
-RWStructuredBuffer<uint> StartOffsetBuffer;
-uint bufferSizeHead ;
+RWByteAddressBuffer StartOffsetBuffer;
+int bufferWidth;
 
-[numthreads(64,1,1)]
-void ClearStartOffsetBuffer (uint3 id : SV_DispatchThreadID)
+[numthreads(32, 32, 1)]
+void ClearStartOffsetBuffer (uint3 id: SV_DispatchThreadID)
 {
-    for(uint i=0;i<bufferSizeHead;i+=4194240){
-        StartOffsetBuffer[id.x + i] = 0;
-    }
+    StartOffsetBuffer.Store(4 * (bufferWidth * id.y + id.x), 0);
 }

--- a/Assets/OrderIndependentTransparency/Shaders/Resources/OitComputeUtils.compute
+++ b/Assets/OrderIndependentTransparency/Shaders/Resources/OitComputeUtils.compute
@@ -1,0 +1,10 @@
+#pragma kernel ClearStartOffsetBuffer
+
+RWStructuredBuffer<uint> StartOffsetBuffer;
+uint IndexOffset = 0;
+
+[numthreads(64,1,1)]
+void ClearStartOffsetBuffer (uint3 id : SV_DispatchThreadID)
+{
+    StartOffsetBuffer[id.x+IndexOffset] = 0;
+}

--- a/Assets/OrderIndependentTransparency/Shaders/Resources/OitComputeUtils.compute.meta
+++ b/Assets/OrderIndependentTransparency/Shaders/Resources/OitComputeUtils.compute.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8166d1d02844f514985e551cdad81e49
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 2097156
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
it can improve the performance in most scenarios， 
but still an limitation,
it can't work properly on a very large screen (e.g. 4K HUD 3840*2160) due to the buffer counts over the max thread group.
but it can be fixed by split thread size into many dispatches with an index offset. 
![original](https://user-images.githubusercontent.com/31602852/190317442-76e95d74-d1e6-46ee-81c3-d6fb93b4bd69.png)
![optimized](https://user-images.githubusercontent.com/31602852/190317449-3e8771f4-4090-45c0-a6c9-56c76f0dc23b.png)
