### PR TITLE
fix(URP): fix missing shader on URP build

### DIFF
--- a/Shaders/Resources/OitRenderURP.shader
+++ b/Shaders/Resources/OitRenderURP.shader
@@ -5,7 +5,7 @@ Shader "Hidden/OitRenderURP"
 		PackageRequirements {
 			"com.unity.render-pipelines.universal"
 		}
-        Tags { "RenderPipeline" = "UniversalRenderPipeline" }
+        Tags { "RenderPipeline" = "UniversalPipeline" }
 		Pass {
             Name "URP Order-Independent Transparency Pass"
 			ZTest Always

--- a/Shared/OitLinkedList.cs
+++ b/Shared/OitLinkedList.cs
@@ -47,6 +47,10 @@ namespace OrderIndependentTransparency
         public Material Render(CommandBuffer command, RenderTargetIdentifier src, RenderTargetIdentifier dest)
         {
             command.ClearRandomWriteTargets();
+            if (linkedListMaterial == null)
+            {
+                return null;
+            }
             // blend linked list
             linkedListMaterial.SetBuffer(fragmentLinkBufferId, fragmentLinkBuffer);
             linkedListMaterial.SetBuffer(startOffsetBufferId, startOffsetBuffer);

--- a/URP/Runtime/OitPass.cs
+++ b/URP/Runtime/OitPass.cs
@@ -30,8 +30,11 @@ namespace OrderIndependentTransparency.URP
             CommandBuffer cmd = CommandBufferPool.Get("Order Independent Transparency");
             var mat = orderIndependentTransparency.Render(cmd, renderingData.cameraData.renderer.cameraColorTargetHandle,
                 renderingData.cameraData.renderer.cameraColorTargetHandle);
-            Blitter.BlitCameraTexture(cmd, renderingData.cameraData.renderer.cameraColorTargetHandle,
-                renderingData.cameraData.renderer.cameraColorTargetHandle, mat, 0);
+            if (mat != null)
+            {
+                Blitter.BlitCameraTexture(cmd, renderingData.cameraData.renderer.cameraColorTargetHandle,
+                    renderingData.cameraData.renderer.cameraColorTargetHandle, mat, 0);
+            }
             context.ExecuteCommandBuffer(cmd);
             cmd.Clear();
             CommandBufferPool.Release(cmd);

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "org.happy-turtle.order-independent-transparency",
   "version": "5.0.0",
-  "unity": "2021.2",
+  "unity": "2022.3",
   "displayName": "Order-independent Transparency",
   "description": "This is an implementation of order-independent transparency for the Built-In Pipeline. It uses Per-Pixel Linked Lists, implemented with RWStructuredBuffers. This is a feature requiring Shader Model 5.0 with ComputeBuffers, see the Unity Manual for supported platforms.",
   "author": {
     "name": "Till Davin",
     "email": "code@tilldavin.de"
   },
-  "dependencies": {},
+  "dependencies": { },
   "samples": [
     {
       "displayName": "Post Process Demo",


### PR DESCRIPTION
Unity renamed the URP shader tag from `UniversalRenderPipeline` to `UniversalPipeline`. This was only noticeable on build with the shader completely missing.